### PR TITLE
Update mc_att_control_params.c

### DIFF
--- a/src/modules/mc_att_control/mc_att_control_params.c
+++ b/src/modules/mc_att_control/mc_att_control_params.c
@@ -103,7 +103,7 @@ PARAM_DEFINE_INT32(DTRG_H_T_X, 8);
  * @reboot_required true
  * @group DTRG
  */
-PARAM_DEFINE_INT32(DTRG_H_T_Y, 9);
+PARAM_DEFINE_INT32(DTRG_H_T_Y, 6);
 
 /**
  * Roll P gain


### PR DESCRIPTION
for safety, changed the default HT thrust parameter to within the PPM range
