### PR TITLE
 Patch in desaturation logic changes from prototype 1 branch

### DIFF
--- a/src/lib/control_allocation/control_allocation/ControlAllocationSequentialDesaturation.cpp
+++ b/src/lib/control_allocation/control_allocation/ControlAllocationSequentialDesaturation.cpp
@@ -183,11 +183,13 @@ ControlAllocationSequentialDesaturation::mixAirmodeDisabled()
 	ActuatorVector thrust_z;
 	ActuatorVector roll;
 	ActuatorVector pitch;
+	ActuatorVector yaw;
 
 	for (int i = 0; i < _num_actuators; i++) {
 		_actuator_sp(i) = _actuator_trim(i) +
 				  _mix(i, ControlAxis::ROLL) * (_control_sp(ControlAxis::ROLL) - _control_trim(ControlAxis::ROLL)) +
 				  _mix(i, ControlAxis::PITCH) * (_control_sp(ControlAxis::PITCH) - _control_trim(ControlAxis::PITCH)) +
+				  _mix(i, ControlAxis::YAW) * (_control_sp(ControlAxis::YAW) - _control_trim(ControlAxis::YAW)) +
 				  _mix(i, ControlAxis::THRUST_X) * (_control_sp(ControlAxis::THRUST_X) - _control_trim(ControlAxis::THRUST_X)) +
 				  _mix(i, ControlAxis::THRUST_Y) * (_control_sp(ControlAxis::THRUST_Y) - _control_trim(ControlAxis::THRUST_Y)) +
 				  _mix(i, ControlAxis::THRUST_Z) * (_control_sp(ControlAxis::THRUST_Z) - _control_trim(ControlAxis::THRUST_Z));
@@ -196,11 +198,15 @@ ControlAllocationSequentialDesaturation::mixAirmodeDisabled()
 		thrust_z(i) = _mix(i, ControlAxis::THRUST_Z);
 		roll(i) = _mix(i, ControlAxis::ROLL);
 		pitch(i) = _mix(i, ControlAxis::PITCH);
+		yaw(i) = _mix(i, ControlAxis::YAW);
 	}
 
 	// First reduce foward thrust, then sideways thrust
-	float x_sat = desaturateActuators(_actuator_sp, thrust_x, true);
-	float y_sat = desaturateActuators(_actuator_sp, thrust_y, true);
+	float x_sat = desaturateActuators(_actuator_sp, thrust_x);
+	float y_sat = desaturateActuators(_actuator_sp, thrust_y);
+
+	// Desaturate yaw
+	float yaw_sat = desaturateActuators(_actuator_sp, yaw);
 
 	// only reduce thrust
 	float z_sat = desaturateActuators(_actuator_sp, thrust_z, true);
@@ -210,7 +216,7 @@ ControlAllocationSequentialDesaturation::mixAirmodeDisabled()
 	float pitch_sat = desaturateActuators(_actuator_sp, pitch);
 
 	// Mix yaw independently
-	float yaw_sat = mixYaw();
+	// float yaw_sat = mixYaw();
 
 	// Assemble into a message
 	sequential_desaturation_s sqmsg{};


### PR DESCRIPTION
There was a bug where the desaturation logic would only be able to increase horizontal thrust, so it effectively didn't do much. This was fixed in the prototype 1 branch a while ago but never made it to the main branch. Now it has.

The new logic is that X will decrease, then Y, then yaw.

