### PR TITLE
Fix Pitch and Roll maximums in manual mode with horizontal motion + Add a disable option for the channels

### DIFF
--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -55,6 +55,7 @@
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_rates_setpoint.h>
 #include <uORB/topics/vehicle_status.h>
+#include <lib/mathlib/mathlib.h>
 #include <lib/mathlib/math/filter/AlphaFilter.hpp>
 #include <lib/slew_rate/SlewRate.hpp>
 #include <lib/stick_yaw/StickYaw.hpp>
@@ -136,13 +137,28 @@ private:
 	bool _heading_good_for_control{true}; // initialized true to have heading lock when local position never published
 	float _unaided_heading{NAN}; // initialized NAN to not distract heading lock when local position never published
 	float _man_tilt_max{0.f};			/**< maximum tilt allowed for manual flight [rad] */
-	float _ht_gain;                    	/**< DTRG horizontal thrust rate */
-	int _ht_en;                        	/**< DTRG horizontal thrust enable */
-	int _ht_rc_en_add;				/**< DTRF HT RC enable channel */
-	int _ht_r_add;                         	/**< DTRG horizontal thrust Roll channel */
-	int _ht_p_add; 		       		/**< DTRG horizontal thrust Pitch channel */
+	float _ht_gain{0.f};                   	/**< DTRG horizontal thrust rate */
+	int _ht_en{0};                       	/**< DTRG horizontal thrust enable */
+	int _ht_rc_en_add{-1};				/**< DTRF HT RC enable channel */
+	// 0-based RC channel indices, -1 when the channel parameter is 0 (input disabled)
+	int _ht_r_add{-1};                     	/**< DTRG horizontal thrust Roll channel */
+	int _ht_p_add{-1}; 	       		/**< DTRG horizontal thrust Pitch channel */
 	float _ht_limit = 0.5f; 		/**< DTRG horizontal horizontal thrust limit */
-	int _dtrg_ht_mask;
+	float _ht_r_limit{math::radians(10.f)};	/**< DTRG horizontal thrust Roll angle limit [rad] */
+	float _ht_p_limit{math::radians(10.f)};	/**< DTRG horizontal thrust Pitch angle limit [rad] */
+	int _dtrg_ht_mask{0};
+
+	/**
+	 * Tilt setpoint from a DTRG-assigned RC channel.
+	 *
+	 * @param channel_index 0-based RC channel, or -1 when DTRG_HT_R/DTRG_HT_P is 0
+	 * @param limit         magnitude limit [rad], from DTRG_HT_R_MAX / DTRG_HT_P_MAX
+	 * @return              0 when the input is disabled, out of range or inside the deadzone
+	 */
+	float dtrgAuxTiltSetpoint(int channel_index, float limit) const;
+
+	/** True when horizontal thrust is enabled and its RC enable switch is held high. */
+	bool htSwitchActive() const;
 
 
 	SlewRate<float> _manual_throttle_minimum{0.f}; ///< 0 when landed and ramped to MPC_MANTHR_MIN in air
@@ -193,6 +209,8 @@ private:
 		(ParamInt<px4::params::DTRG_HT_R>)  	    _param_dtrg_h_t_R,		/**< horizontal thrust Roll channel */
 		(ParamInt<px4::params::DTRG_HT_P>)  	    _param_dtrg_h_t_P,		/**< horizontal thrust Pitch channel */
 		(ParamFloat<px4::params::DTRG_HT_MAX>)      _param_dtrg_ht_max,		/**< horizontal thrust Limit */
+		(ParamFloat<px4::params::DTRG_HT_R_MAX>)    _param_dtrg_ht_r_max,	/**< horizontal thrust roll angle Limit */
+		(ParamFloat<px4::params::DTRG_HT_P_MAX>)    _param_dtrg_ht_p_max,	/**< horizontal thrust pitch angle Limit */
 		(ParamInt<px4::params::DTRG_HT_MASK>)       _param_dtrg_ht_mask		/**< HT gmask for pitching and rolling using HT thrust*/
 
 	)

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -109,11 +109,48 @@ MulticopterAttitudeControl::parameters_updated()
 	if (_ht_en){
 		_ht_rc_en_add = _param_dtrg_ht_rc_en.get()-1;
 		_ht_limit = _param_dtrg_ht_max.get();
-		_ht_r_add = _param_dtrg_h_t_R.get()-1;
-		_ht_p_add = _param_dtrg_h_t_P.get()-1;
+		// DTRG_HT_R / DTRG_HT_P of 0 means the input is disabled. Keep the sentinel
+		// at -1 rather than letting the -1 offset produce a negative index into
+		// rc_channels.channels[].
+		_ht_r_add = (_param_dtrg_h_t_R.get() > 0) ? (_param_dtrg_h_t_R.get() - 1) : -1;
+		_ht_p_add = (_param_dtrg_h_t_P.get() > 0) ? (_param_dtrg_h_t_P.get() - 1) : -1;
+		_ht_r_limit = math::radians(_param_dtrg_ht_r_max.get());
+		_ht_p_limit = math::radians(_param_dtrg_ht_p_max.get());
 		_dtrg_ht_mask = _param_dtrg_ht_mask.get();
 	}
 
+}
+
+float
+MulticopterAttitudeControl::dtrgAuxTiltSetpoint(int channel_index, float limit) const
+{
+	// A channel parameter of 0 disables that input, which arrives here as -1. The
+	// upper bound is a belt-and-braces check on the channel parameters, which are
+	// not range-checked anywhere else before being used as an array index.
+	const int num_channels = static_cast<int>(sizeof(_rc_channels.channels) / sizeof(_rc_channels.channels[0]));
+
+	if ((channel_index < 0) || (channel_index >= num_channels)) {
+		return 0.f;
+	}
+
+	const float raw = _rc_channels.channels[channel_index];
+
+	// deadzone
+	if (!PX4_ISFINITE(raw) || (fabsf(raw) <= 0.02f)) {
+		return 0.f;
+	}
+
+	return math::constrain(raw * limit, -limit, limit);
+}
+
+bool
+MulticopterAttitudeControl::htSwitchActive() const
+{
+	const int num_channels = static_cast<int>(sizeof(_rc_channels.channels) / sizeof(_rc_channels.channels[0]));
+
+	return (_ht_en != 0)
+	       && (_ht_rc_en_add >= 0) && (_ht_rc_en_add < num_channels)
+	       && (_rc_channels.channels[_ht_rc_en_add] > 0.5f);
 }
 
 float
@@ -182,9 +219,12 @@ MulticopterAttitudeControl::generate_attitude_setpoint(const Quatf &q, float dt)
 
 
 
-	if (_ht_en && (_rc_channels.channels[_ht_rc_en_add] > 0.5f)){
-		v = Vector2f(_man_roll_input_filter.update(_rc_channels.channels[_ht_r_add] * _man_tilt_max),
-		-_man_pitch_input_filter.update(_rc_channels.channels[_ht_p_add] * _man_tilt_max));
+	if (htSwitchActive()){
+		// Roll/pitch come from the assigned aux channels, scaled by the DTRG angle
+		// limits (DTRG_HT_R_MAX / DTRG_HT_P_MAX) rather than the manual tilt max.
+		// A channel parameter of 0 disables that axis, leaving its tilt at 0.
+		v = Vector2f(_man_roll_input_filter.update(dtrgAuxTiltSetpoint(_ht_r_add, _ht_r_limit)),
+			     -_man_pitch_input_filter.update(dtrgAuxTiltSetpoint(_ht_p_add, _ht_p_limit)));
 	}else{
 		v = Vector2f(_man_roll_input_filter.update(_manual_control_setpoint.roll * _man_tilt_max),
 				      -_man_pitch_input_filter.update(_manual_control_setpoint.pitch * _man_tilt_max));
@@ -215,7 +255,7 @@ MulticopterAttitudeControl::generate_attitude_setpoint(const Quatf &q, float dt)
 	}
 
 	// DTRG horizontal thrust: override roll/pitch quaternion and thrust when HT is active
-	if (_ht_en && (_rc_channels.channels[_ht_rc_en_add] > 0.5f)) {
+	if (htSwitchActive()) {
 		// Recalculate quaternion based on HT mask mode
 		Vector2f v_ht;
 
@@ -259,7 +299,7 @@ MulticopterAttitudeControl::generate_attitude_setpoint(const Quatf &q, float dt)
 	attitude_setpoint.thrust_body[2] = -throttle_curve(_manual_control_setpoint.throttle);
 
 	// DTRG horizontal thrust switch
-	if (_ht_en && (_rc_channels.channels[_ht_rc_en_add] > 0.5f)) {
+	if (htSwitchActive()) {
 		// DTRG horizontal thrust saturation topic
 		horizontal_thrust_limit_s hzlim_msg{};
 		hzlim_msg.timestamp = hrt_absolute_time();

--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -309,8 +309,11 @@ void MulticopterPositionControl::parameters_update(bool force)
 		_ht_en = _param_dtrg_ht_en.get();
 		if (_ht_en){
 			_ht_rc_en_add = _param_dtrg_ht_rc_en.get()-1;
-			_ht_r_add = _param_dtrg_ht_R.get()-1;
-			_ht_p_add = _param_dtrg_ht_P.get()-1;
+			// DTRG_HT_R / DTRG_HT_P of 0 means the input is disabled. Keep the
+			// sentinel at -1 rather than letting the -1 offset produce a negative
+			// index into rc_channels.channels[].
+			_ht_r_add = (_param_dtrg_ht_R.get() > 0) ? (_param_dtrg_ht_R.get() - 1) : -1;
+			_ht_p_add = (_param_dtrg_ht_P.get() > 0) ? (_param_dtrg_ht_P.get() - 1) : -1;
 			_dtrg_ht_mask = _param_dtrg_ht_mask.get();
 			_ht_limit = _param_dtrg_ht_max.get();
 			_ht_r_limit = math::radians(_param_dtrg_ht_r_max.get());
@@ -319,6 +322,27 @@ void MulticopterPositionControl::parameters_update(bool force)
 
 
 	}
+}
+
+float MulticopterPositionControl::dtrgAuxTiltSetpoint(int channel_index, float limit) const
+{
+	// A channel parameter of 0 disables that input, which arrives here as -1. The
+	// upper bound is a belt-and-braces check on the channel parameters, which are
+	// not range-checked anywhere else before being used as an array index.
+	const int num_channels = static_cast<int>(sizeof(_rc_channels.channels) / sizeof(_rc_channels.channels[0]));
+
+	if ((channel_index < 0) || (channel_index >= num_channels)) {
+		return 0.f;
+	}
+
+	const float raw = _rc_channels.channels[channel_index];
+
+	// deadzone
+	if (!PX4_ISFINITE(raw) || (fabsf(raw) <= 0.02f)) {
+		return 0.f;
+	}
+
+	return math::constrain(raw * limit, -limit, limit);
 }
 
 PositionControlStates MulticopterPositionControl::set_vehicle_states(const vehicle_local_position_s
@@ -626,20 +650,20 @@ void MulticopterPositionControl::Run()
 
 			// Publish attitude setpoint output
 			vehicle_attitude_setpoint_s attitude_setpoint{};
-			if(_ht_en && (_rc_channels.channels[_ht_rc_en_add] > 0.5f)){
+			const bool ht_rc_enabled = (_ht_rc_en_add >= 0)
+						   && (_ht_rc_en_add < static_cast<int>(sizeof(_rc_channels.channels) / sizeof(
+									   _rc_channels.channels[0])))
+						   && (_rc_channels.channels[_ht_rc_en_add] > 0.5f);
+
+			if(_ht_en && ht_rc_enabled){
 
 				if(!_vehicle_control_mode.flag_control_offboard_enabled){
 					// if offboard is not enabled, use the RC channels to get roll and pitch setpoints
-					// setpoints are constrained to the limits set by the with 0.01f deadzone
-					roll_setpoint = math::constrain(
-						fabsf(_rc_channels.channels[_ht_r_add]) > 0.02f ?
-						_rc_channels.channels[_ht_r_add] * _ht_r_limit : 0.f,
-						-_ht_r_limit, _ht_r_limit);
-
-					pitch_setpoint = math::constrain(
-						fabsf(_rc_channels.channels[_ht_p_add]) > 0.02f ?
-						_rc_channels.channels[_ht_p_add] * _ht_p_limit : 0.f,
-						-_ht_p_limit, _ht_p_limit);
+					// setpoints are constrained to the limits set by the with 0.02f deadzone.
+					// DTRG_HT_R / DTRG_HT_P of 0 disables that axis' stick input, which
+					// leaves the corresponding setpoint at 0 (level).
+					roll_setpoint = dtrgAuxTiltSetpoint(_ht_r_add, _ht_r_limit);
+					pitch_setpoint = dtrgAuxTiltSetpoint(_ht_p_add, _ht_p_limit);
 				}else{
 					if (_debug_array_sub.update(&_debug_array)){
 

--- a/src/modules/mc_pos_control/MulticopterPositionControl.hpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.hpp
@@ -42,6 +42,7 @@
 #include "GotoControl/GotoControl.hpp"
 
 #include <drivers/drv_hrt.h>
+#include <lib/mathlib/mathlib.h>
 #include <lib/mathlib/math/filter/AlphaFilter.hpp>
 #include <lib/mathlib/math/filter/NotchFilter.hpp>
 #include <lib/mathlib/math/WelfordMean.hpp>
@@ -141,15 +142,27 @@ private:
 	float roll_setpoint = 0.0f;
 	float pitch_setpoint = 0.0f;
 	float _ht_limit = 0.5f; 		/**< DTRG horizontal horizontal thrust limit */
-	float _ht_r_limit = 10.0f;		/**< DTRG horizontal thrust Roll limit */
-	float _ht_p_limit = 10.0f;		/**< DTRG horizontal thrust Pitch limit */
-	int _ht_en; 				/**< DTRG horizontal thrust Enabled*/
-	int _ht_rc_en_add;			/**< DTRF HT RC enable channel */
+	// Assigned as radians in parameters_update(); the in-class default must match the
+	// unit or an un-updated instance would carry a 573 deg limit.
+	float _ht_r_limit{math::radians(10.f)};	/**< DTRG horizontal thrust Roll limit [rad] */
+	float _ht_p_limit{math::radians(10.f)};	/**< DTRG horizontal thrust Pitch limit [rad] */
+	int _ht_en{0}; 				/**< DTRG horizontal thrust Enabled*/
+	int _ht_rc_en_add{-1};			/**< DTRF HT RC enable channel */
 	int _dtrg_ht_mask = 0;
-	int _ht_x_add;                         	/**< DTRG horizontal thrust X channel */
-	int _ht_y_add;                         	/**< DTRG horizontal thrust Y channel */
-	int _ht_r_add;                         	/**< DTRG horizontal thrust Roll channel */
-	int _ht_p_add; 		       		/**< DTRG horizontal thrust Pitch channel */
+	int _ht_x_add{-1};                     	/**< DTRG horizontal thrust X channel */
+	int _ht_y_add{-1};                     	/**< DTRG horizontal thrust Y channel */
+	// 0-based RC channel indices, -1 when the channel parameter is 0 (input disabled)
+	int _ht_r_add{-1};                     	/**< DTRG horizontal thrust Roll channel */
+	int _ht_p_add{-1}; 	       		/**< DTRG horizontal thrust Pitch channel */
+
+	/**
+	 * Scaled tilt setpoint from a DTRG-assigned RC channel.
+	 *
+	 * @param channel_index 0-based RC channel, or -1 when DTRG_HT_R/DTRG_HT_P is 0
+	 * @param limit         magnitude limit [rad]
+	 * @return              0 when the input is disabled, out of range or inside the deadzone
+	 */
+	float dtrgAuxTiltSetpoint(int channel_index, float limit) const;
 
 
 	vehicle_land_detected_s _vehicle_land_detected {

--- a/src/modules/mc_pos_control/multicopter_horizontal_thrust_params.c
+++ b/src/modules/mc_pos_control/multicopter_horizontal_thrust_params.c
@@ -9,28 +9,40 @@
  *
  * AUX channel for horizontal thrust roll control in 6DOF mode.
  *
- * @min 1
+ * @min 0
  * @max 16
+ * @value 0 Disabled
+ * @value 9 AUX9
  * @value 10 AUX10
  * @value 11 AUX11
  * @value 12 AUX12
+ * @value 13 AUX13
+ * @value 14 AUX14
+ * @value 15 AUX15
+ * @value 16 AUX16
  * @group DTRG
  */
-PARAM_DEFINE_INT32(DTRG_HT_R, 10);
+PARAM_DEFINE_INT32(DTRG_HT_R, 0);
 
 /**
  * Horizontal thrust Pitch channel
  *
  * AUX channel for horizontal thrust pitch control in 6DOF mode.
  *
- * @min 1
+ * @min 0
  * @max 16
+ * @value 0 Disabled
+ * @value 9 AUX9
  * @value 10 AUX10
  * @value 11 AUX11
  * @value 12 AUX12
+ * @value 13 AUX13
+ * @value 14 AUX14
+ * @value 15 AUX15
+ * @value 16 AUX16
  * @group DTRG
  */
-PARAM_DEFINE_INT32(DTRG_HT_P, 11);
+PARAM_DEFINE_INT32(DTRG_HT_P, 0);
 
 /**
  * Horizontal thrust control mask


### PR DESCRIPTION
Previously the maximums of pitch and roll were scaled by maximum of pitch and roll of the attitude mode, rather than the restricted DTRG one. Could cause problems. 

Allowed those to be disabled as well to clear channel