### PR TITLE
Salz167/fixes test and switch assignment

### DIFF
--- a/src/lib/control_allocation/control_allocation/ControlAllocationSequentialDesaturation.hpp
+++ b/src/lib/control_allocation/control_allocation/ControlAllocationSequentialDesaturation.hpp
@@ -86,7 +86,7 @@ private:
 	 * @param increase_only if true, only allow to increase (add) a fraction of desaturation_vector
 	 */
 	float desaturateActuators(ActuatorVector &actuator_sp, const ActuatorVector &desaturation_vector,
-				 bool increase_only = false);
+				  bool increase_only = false);
 
 	/**
 	 * Computes the gain k by which desaturation_vector has to be multiplied

--- a/src/modules/bench_test/BenchTest.cpp
+++ b/src/modules/bench_test/BenchTest.cpp
@@ -244,7 +244,7 @@ float BenchTest::signFromSwitch()
 		return 0.f;
 	}
 
-	return bench_test::signFromInputRc(input_rc, _param_BT_SIGN_SW.get());
+	return bench_test::signFromInputRc(input_rc, _param_bt_cmd_sign.get());
 }
 
 BenchTest::ProfileParams BenchTest::currentProfileParams()
@@ -397,7 +397,7 @@ int BenchTest::print_status()
 	PX4_INFO("mode: %d, axis: %d, sign_sw: %d, arm_enable: %d",
 		 (int)_param_bt_mode.get(),
 		 (int)_param_bt_axis.get(),
-		 (int)_param_BT_SIGN_SW.get(),
+		 (int)_param_bt_cmd_sign.get(),
 		 (int)_param_bt_arm_enable.get());
 	PX4_INFO("sign: %d, ramp_frozen: %d, ramp_value: %.3f",
 		 (int)signFromSwitch(),
@@ -423,7 +423,7 @@ system identification on a rigidly mounted vehicle. Sub-mode (hover / step /
 ramp), axis, and magnitudes are controlled via BT_* parameters. Only outputs
 non-zero commands when the vehicle is armed AND BT_ARM_ENABLE is 1.
 
-A single 3-position RC switch on the raw RC channel selected with BT_SIGN_SW
+A single 3-position RC switch on the raw RC channel selected with RC_MAP_CMD_SIGN
 runs the profile: up (>1700us) excites positive, down (<1300us) negative, and
 centre commands no excitation (hover baseline only). Moving off centre starts
 the profile and moving to the other side restarts it. The ramp increases until
@@ -434,7 +434,7 @@ BT_RAMP_RATE, BT_MAX_VAL) also restarts the profile from t = 0.
 
 Arming is refused while the direction switch is off centre, so the excitation
 cannot start as the motors spin up. This does not apply in hover-only mode
-(BT_MODE = 0) or when no switch is assigned (BT_SIGN_SW = 0).
+(BT_MODE = 0) or when no switch is assigned (RC_MAP_CMD_SIGN = 0).
 
 When the outputs first become active the hover baseline is ramped up from zero
 over BT_SPINUP_T (throttle spin-up). Disarming is permitted in this mode even

--- a/src/modules/bench_test/BenchTest.hpp
+++ b/src/modules/bench_test/BenchTest.hpp
@@ -95,7 +95,7 @@ private:
 	float computeAxisOutput(float sign, float dt_since_start, bool motor_saturated);
 
 	// Direction of the excitation, taken from the 3-position RC switch selected by
-	// BT_SIGN_SW: +1 (switch up), -1 (switch down), 0 (centre / no excitation).
+	// RC_MAP_CMD_SIGN: +1 (switch up), -1 (switch down), 0 (centre / no excitation).
 	// Off-centre is what starts the profile; there is no separate start switch.
 	float signFromSwitch();
 
@@ -151,7 +151,7 @@ private:
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::BT_MODE>)        _param_bt_mode,
 		(ParamInt<px4::params::BT_AXIS>)        _param_bt_axis,
-		(ParamInt<px4::params::BT_SIGN_SW>)     _param_BT_SIGN_SW,
+		(ParamInt<px4::params::RC_MAP_CMD_SIGN>)     _param_bt_cmd_sign,
 		(ParamFloat<px4::params::BT_HOVER_THR>) _param_bt_hover_thr,
 		(ParamFloat<px4::params::BT_STEP_MAG>)  _param_bt_step_mag,
 		(ParamFloat<px4::params::BT_STEP_DELAY>)_param_bt_step_delay,

--- a/src/modules/bench_test/README.md
+++ b/src/modules/bench_test/README.md
@@ -20,7 +20,7 @@ signal while thrust/torque, motor outputs, and IMU response are logged.
   one chosen axis.
 - The hover baseline is **soft-started**: it ramps up from zero to `BT_HOVER_THR`
   over `BT_SPINUP_T` seconds each time the outputs become active.
-- A **single 3-position RC switch** (`BT_SIGN_SW`) runs the whole profile:
+- A **single 3-position RC switch** (`RC_MAP_CMD_SIGN`) runs the whole profile:
   centre = no excitation, up = positive, down = negative. Moving off centre
   starts the profile, and moving to the other side restarts it.
 - In **ramp** mode the excitation increases until a motor **saturates** (within a
@@ -32,7 +32,7 @@ signal while thrust/torque, motor outputs, and IMU response are logged.
 - **Arming is refused** while the direction switch is off centre (*"Arming
   denied: centre the bench test direction switch"*), so the excitation cannot
   start the instant the motors spin up. Not applied in hover-only mode
-  (`BT_MODE = 0`) or when no switch is assigned (`BT_SIGN_SW = 0`).
+  (`BT_MODE = 0`) or when no switch is assigned (`RC_MAP_CMD_SIGN = 0`).
 - **Entering the mode while armed is refused** (*"Bench test mode denied: disarm
   first"*): you must be disarmed to switch into Bench Test.
 
@@ -42,7 +42,7 @@ signal while thrust/torque, motor outputs, and IMU response are logged.
    rig.
 2. **Assign the mode** to a flight-mode switch position via `COM_FLTMODEx = 16`
    (Bench Test).
-3. **Assign the direction switch**: set `BT_SIGN_SW` to the RC channel of a
+3. **Assign the direction switch**: set `RC_MAP_CMD_SIGN` to the RC channel of a
    3-position switch (e.g. `15` for AUX15). Centre = no excitation, up =
    positive, down = negative. This one switch both starts the profile and sets
    its direction.
@@ -79,7 +79,7 @@ All parameters are in the **Bench Test** group.
 |----------------|-------|---------|-------------|
 | `BT_MODE`      | int   | `0`     | Excitation profile: `0` hover only, `1` step, `2` ramp. |
 | `BT_AXIS`      | int   | `2`     | Axis under excitation: `0` thrust X, `1` thrust Y, `2` thrust Z (collective), `3` roll torque, `4` pitch torque, `5` yaw torque. Horizontal thrust axes (X, Y) are only realisable on fully-actuated / omni / tilt-rotor airframes. |
-| `BT_SIGN_SW`   | int   | `0`     | Raw RC channel (`input_rc`) of the 3-position direction switch: high (>1700 µs) → positive excitation, low (<1300 µs) → negative, centre → no excitation. `0` disables the excitation entirely. |
+| `RC_MAP_CMD_SIGN`   | int   | `0`     | Raw RC channel (`input_rc`) of the 3-position direction switch: high (>1700 µs) → positive excitation, low (<1300 µs) → negative, centre → no excitation. `0` disables the excitation entirely. |
 | `BT_HOVER_THR` | float | `0.5`   | Baseline hover thrust (normalised, 0–1), published as `-BT_HOVER_THR` on the Z body axis (NED: −Z is up). |
 
 ### Step profile (`BT_MODE = 1`)
@@ -114,7 +114,7 @@ All parameters are in the **Bench Test** group.
 ## Notes and behaviour details
 
 - **Output gate vs. direction switch** are independent: `BT_ARM_ENABLE` must be
-  `1` for *any* output (and for arming at all); `BT_SIGN_SW` only controls when
+  `1` for *any* output (and for arming at all); `RC_MAP_CMD_SIGN` only controls when
   and in which direction the excitation runs on top of the hover baseline.
 - **Saturation** is evaluated on `actuator_motors.control` (the normalised
   allocator output), limited to the connected motors. This is the signal the

--- a/src/modules/bench_test/bench_test_params.c
+++ b/src/modules/bench_test/bench_test_params.c
@@ -75,18 +75,24 @@ PARAM_DEFINE_INT32(BT_AXIS, 2);
  * it to the other side restarts it, so each flip runs the profile from the
  * start. Set to 0 to disable the excitation entirely (hover baseline only).
  *
+ * @min 0
+ * @max 16
  * @value 0 Disabled
- * @value 9 AUX9
- * @value 10 AUX10
- * @value 11 AUX11
- * @value 12 AUX12
- * @value 13 AUX13
- * @value 14 AUX14
- * @value 15 AUX15
- * @value 16 AUX16
+ * @value 5 Channel 5
+ * @value 6 Channel 6
+ * @value 7 Channel 7
+ * @value 8 Channel 8
+ * @value 9 Channel 9
+ * @value 10 Channel 10
+ * @value 11 Channel 11
+ * @value 12 Channel 12
+ * @value 13 Channel 13
+ * @value 14 Channel 14
+ * @value 15 Channel 15
+ * @value 16 Channel 16
  * @group Bench Test
  */
-PARAM_DEFINE_INT32(BT_SIGN_SW, 0);
+PARAM_DEFINE_INT32(RC_MAP_CMD_SIGN, 0);
 
 /**
  * Bench test hover thrust

--- a/src/modules/bench_test/bench_test_switch.h
+++ b/src/modules/bench_test/bench_test_switch.h
@@ -34,7 +34,7 @@
 /**
  * @file bench_test_switch.h
  *
- * Shared decoding of the bench test 3-position direction switch (BT_SIGN_SW).
+ * Shared decoding of the bench test 3-position direction switch (RC_MAP_CMD_SIGN).
  * Header-only so commander can apply the same interpretation for its arming
  * check without depending on the bench_test module being built.
  */
@@ -75,7 +75,7 @@ static inline float signFromPulse(uint16_t value)
  * Decode the direction switch from an input_rc sample.
  *
  * @param input_rc raw RC sample
- * @param channel  1-based channel number (BT_SIGN_SW), 0 = disabled
+ * @param channel  1-based channel number (RC_MAP_CMD_SIGN), 0 = disabled
  * @return +1 / -1 / 0. Returns 0 (centre) for a disabled or out-of-range
  *         channel and on RC loss, so both users fail safe to "no excitation".
  */
@@ -89,7 +89,7 @@ static inline float signFromInputRc(const input_rc_s &input_rc, int32_t channel)
 		return 0.f;
 	}
 
-	const int channel_index = channel - 1; // BT_SIGN_SW is 1-based
+	const int channel_index = channel - 1; // RC_MAP_CMD_SIGN is 1-based
 
 	if ((channel_index >= input_rc.channel_count)
 	    || (channel_index >= (int)input_rc_s::RC_INPUT_MAX_CHANNELS)) {

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -580,7 +580,7 @@ transition_result_t Commander::arm(arm_disarm_reason_t calling_reason, bool run_
 		int32_t bench_test_mode = 0;
 		int32_t bench_test_sign_sw = 0;
 		const param_t bench_test_mode_handle = param_find_no_notification("BT_MODE");
-		const param_t bench_test_sign_sw_handle = param_find_no_notification("BT_SIGN_SW");
+		const param_t bench_test_sign_sw_handle = param_find_no_notification("RC_MAP_CMD_SIGN");
 
 		if ((bench_test_mode_handle != PARAM_INVALID) && (bench_test_sign_sw_handle != PARAM_INVALID)
 		    && (param_get(bench_test_mode_handle, &bench_test_mode) == PX4_OK)

--- a/src/modules/commander/HealthAndArmingChecks/CMakeLists.txt
+++ b/src/modules/commander/HealthAndArmingChecks/CMakeLists.txt
@@ -62,6 +62,7 @@ px4_add_library(health_and_arming_checks
 	checks/parachuteCheck.cpp
 	checks/powerCheck.cpp
 	checks/rcAndDataLinkCheck.cpp
+	checks/rcChannelConflictCheck.cpp
 	checks/rcCalibrationCheck.cpp
 	checks/sdcardCheck.cpp
 	checks/systemCheck.cpp

--- a/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.hpp
@@ -69,6 +69,7 @@
 #include "checks/flightTimeCheck.hpp"
 #include "checks/missionCheck.hpp"
 #include "checks/rcAndDataLinkCheck.hpp"
+#include "checks/rcChannelConflictCheck.hpp"
 #include "checks/vtolCheck.hpp"
 #include "checks/offboardCheck.hpp"
 #include "checks/openDroneIDCheck.hpp"
@@ -155,6 +156,7 @@ private:
 	FlightTimeChecks _flight_time_checks;
 	MissionChecks _mission_checks;
 	RcAndDataLinkChecks _rc_and_data_link_checks;
+	RcChannelConflictChecks _rc_channel_conflict_checks;
 	VtolChecks _vtol_checks;
 	OffboardChecks _offboard_checks;
 #ifndef CONSTRAINED_FLASH
@@ -196,6 +198,7 @@ private:
 		&_geofence_checks, // must be after _home_position_checks
 		&_flight_time_checks,
 		&_rc_and_data_link_checks,
+		&_rc_channel_conflict_checks,
 		&_vtol_checks,
 	};
 };

--- a/src/modules/commander/HealthAndArmingChecks/checks/rcChannelConflictCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/rcChannelConflictCheck.cpp
@@ -1,0 +1,310 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2025 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "rcChannelConflictCheck.hpp"
+
+#include <uORB/topics/input_rc.h>
+
+#include <string.h>
+
+// C++14 still requires out-of-line definitions for odr-used constexpr static members
+constexpr const char *RcChannelConflictChecks::kChannelParamPrefix;
+constexpr const char *RcChannelConflictChecks::kIgnoredParams[];
+constexpr RcChannelConflictChecks::ParamException RcChannelConflictChecks::kExceptions[];
+
+/// bitmask of all channels that can physically exist, bit 0 = channel 1
+static constexpr uint32_t kAllChannelsMask = (1u << input_rc_s::RC_INPUT_MAX_CHANNELS) - 1;
+
+RcChannelConflictChecks::RcChannelConflictChecks()
+{
+	discoverAssignments();
+	updateChannelCache();
+}
+
+bool RcChannelConflictChecks::isChannelParamName(const char *name)
+{
+	return strncmp(name, kChannelParamPrefix, strlen(kChannelParamPrefix)) == 0;
+}
+
+void RcChannelConflictChecks::discoverAssignments()
+{
+	// the exceptions go first, so that a parameter matching neither naming rule is
+	// still checked, and so that its gate and kind are applied
+	for (const ParamException &exception : kExceptions) {
+		addAssignment(exception.name);
+	}
+
+	for (unsigned i = 0; i < param_count(); ++i) {
+		const param_t handle = param_for_index(i);
+
+		if ((handle == PARAM_INVALID) || (param_type(handle) != PARAM_TYPE_INT32)) {
+			continue;
+		}
+
+		const char *name = param_name(handle);
+
+		if ((name == nullptr) || !isChannelParamName(name)) {
+			continue;
+		}
+
+		bool ignored = false;
+
+		for (const char *ignored_name : kIgnoredParams) {
+			if (strcmp(name, ignored_name) == 0) {
+				ignored = true;
+				break;
+			}
+		}
+
+		if (!ignored) {
+			addAssignment(name);
+		}
+	}
+}
+
+void RcChannelConflictChecks::addAssignment(const char *name)
+{
+	const param_t handle = param_find_no_notification(name);
+
+	if (handle == PARAM_INVALID) {
+		// parameter is not part of this build (the owning module is not enabled)
+		return;
+	}
+
+	for (int i = 0; i < _num_assignments; ++i) {
+		if (_assignments[i].handle == handle) {
+			return;
+		}
+	}
+
+	if (_num_assignments >= kMaxAssignments) {
+		PX4_ERR("too many RC channel assignment params, %s not checked", name);
+		return;
+	}
+
+	ChannelAssignment &assignment = _assignments[_num_assignments++];
+	assignment.name = param_name(handle);
+	assignment.handle = handle;
+
+	for (const ParamException &exception : kExceptions) {
+		if (strcmp(assignment.name, exception.name) != 0) {
+			continue;
+		}
+
+		assignment.kind = exception.kind;
+
+		if (exception.gate_name != nullptr) {
+			// a missing gate parameter leaves the handle invalid, which disables the assignment
+			assignment.gate_handle = param_find_no_notification(exception.gate_name);
+			assignment.gated = true;
+			assignment.gate_active_when_zero = exception.gate_active_when_zero;
+		}
+
+		break;
+	}
+}
+
+void RcChannelConflictChecks::updateChannelCache()
+{
+	for (int i = 0; i < _num_assignments; ++i) {
+		_assignments[i].channels = activeChannels(_assignments[i]);
+	}
+}
+
+void RcChannelConflictChecks::updateParams()
+{
+	HealthAndArmingCheckBase::updateParams();
+	updateChannelCache();
+	announceConflicts();
+}
+
+uint32_t RcChannelConflictChecks::conflictingChannels() const
+{
+	uint32_t seen = 0;
+	uint32_t conflicting = 0;
+
+	for (int i = 0; i < _num_assignments; ++i) {
+		conflicting |= seen & _assignments[i].channels;
+		seen |= _assignments[i].channels;
+	}
+
+	return conflicting;
+}
+
+void RcChannelConflictChecks::announceConflicts()
+{
+	const uint32_t conflicts = conflictingChannels();
+	const hrt_abstime now = hrt_absolute_time();
+
+	if (conflicts == 0) {
+		if (_reported_conflicts != 0) {
+			mavlink_log_info(&_mavlink_log_pub, "RC channel conflict resolved");
+			_reported_conflicts = 0;
+		}
+
+		return;
+	}
+
+	// Repeat while the conflict stands rather than only on the edge: the first
+	// message is often emitted before the ground station has connected, and a
+	// statustext is not replayed to a station that joins later.
+	if ((conflicts == _reported_conflicts) && (now < _last_conflict_message + kConflictMessageInterval)) {
+		return;
+	}
+
+	_reported_conflicts = conflicts;
+	_last_conflict_message = now;
+
+	// no trailing tab: unlike the arming check report this message has no matching
+	// event, so the ground station must show the text itself. Keep it inside
+	// MAVLINK_LOG_MAXLEN (50) or it is truncated.
+	const bool blocks_arming = (_param_com_arm_rc_conf.get() == 0);
+	int reported_pairs = 0;
+
+	for (int i = 0; (i < _num_assignments) && (reported_pairs < kMaxReportedPairs); ++i) {
+		for (int j = i + 1; (j < _num_assignments) && (reported_pairs < kMaxReportedPairs); ++j) {
+			const uint32_t overlap = _assignments[i].channels & _assignments[j].channels;
+
+			if (overlap == 0) {
+				continue;
+			}
+
+			const int channel = __builtin_ctz(overlap) + 1;
+			++reported_pairs;
+
+			if (blocks_arming) {
+				mavlink_log_critical(&_mavlink_log_pub, "RC ch %d: %s and %s", channel,
+						     _assignments[i].name, _assignments[j].name);
+
+			} else {
+				mavlink_log_warning(&_mavlink_log_pub, "RC ch %d: %s and %s", channel,
+						    _assignments[i].name, _assignments[j].name);
+			}
+		}
+	}
+}
+
+uint32_t RcChannelConflictChecks::activeChannels(const ChannelAssignment &assignment) const
+{
+	if (assignment.gated) {
+		if (assignment.gate_handle == PARAM_INVALID) {
+			return 0;
+		}
+
+		int32_t gate = 0;
+
+		if (param_get(assignment.gate_handle, &gate) != PX4_OK) {
+			return 0;
+		}
+
+		if ((gate == 0) != assignment.gate_active_when_zero) {
+			return 0;
+		}
+	}
+
+	int32_t value = 0;
+
+	if (param_get(assignment.handle, &value) != PX4_OK) {
+		return 0;
+	}
+
+	// 0 means unassigned; a value outside the RC range is rejected by the consumers
+	// anyway, so it cannot collide with anything.
+	if (value <= 0) {
+		return 0;
+	}
+
+	if (assignment.kind == ParamKind::Bitmask) {
+		return (uint32_t)value & kAllChannelsMask;
+	}
+
+	if (value > input_rc_s::RC_INPUT_MAX_CHANNELS) {
+		return 0;
+	}
+
+	return 1u << (value - 1);
+}
+
+void RcChannelConflictChecks::checkAndReport(const Context &context, Report &reporter)
+{
+	if (context.isArmed()) {
+		// configuration check: the assignments cannot change meaningfully while armed
+		return;
+	}
+
+	// also from here, not just on parameter update, so that a ground station which
+	// connects after the assignment was made still gets told
+	announceConflicts();
+
+	// COM_ARM_RC_CONF = 1 keeps the report but leaves arming possible
+	const bool blocks_arming = (_param_com_arm_rc_conf.get() == 0);
+	const NavModes affected_modes = blocks_arming ? NavModes::All : NavModes::None;
+
+	for (int i = 0; i < _num_assignments; ++i) {
+		const uint32_t channels = _assignments[i].channels;
+
+		if (channels == 0) {
+			continue;
+		}
+
+		for (int j = i + 1; j < _num_assignments; ++j) {
+			const uint32_t overlap = channels & _assignments[j].channels;
+
+			if (overlap == 0) {
+				continue;
+			}
+
+			// report the lowest channel the two have in common
+			const int32_t channel = __builtin_ctz(overlap) + 1;
+
+			/* EVENT
+			 * @description
+			 * Two features are configured to read the same RC channel, so one stick
+			 * or switch would drive both at once.
+			 *
+			 * <profile name="dev">
+			 * Assign a different channel to one of them, or set <param>COM_ARM_RC_CONF</param>
+			 * to warn without blocking arming.
+			 * </profile>
+			 */
+			reporter.armingCheckFailure<uint8_t>(affected_modes, health_component_t::remote_control,
+							     events::ID("check_rc_channel_conflict"),
+							     events::Log::Error, "RC channel {1} assigned to more than one function", channel);
+
+			if (blocks_arming && reporter.mavlink_log_pub()) {
+				mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: %s and %s both use RC channel %d\t",
+						     _assignments[i].name, _assignments[j].name, (int)channel);
+			}
+		}
+	}
+}

--- a/src/modules/commander/HealthAndArmingChecks/checks/rcChannelConflictCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/rcChannelConflictCheck.hpp
@@ -1,0 +1,187 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2025 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "../Common.hpp"
+
+#include <parameters/param.h>
+
+/**
+ * Detects two switch or channel functions being assigned to the same raw RC channel.
+ *
+ * The standard PX4 switches (arm, kill, flight mode, ...) and the DTRG horizontal
+ * thrust and bench test features each let the operator nominate an RC channel by
+ * number. Nothing stops two of them naming the same channel, in which case one
+ * stick or switch drives two functions at once - moving the bench test direction
+ * switch would also command a tilt, or flipping the arm switch would kill the
+ * motors. This check fails arming while such an overlap is configured.
+ *
+ * There is no list of parameters to maintain. The parameter table is scanned once
+ * at boot and every INT32 parameter whose name starts with "RC_MAP"
+ * (kChannelParamPrefix), the PX4 channel mapping convention, is picked up. A new
+ * feature therefore joins the check purely by naming its parameter, without
+ * touching commander. kExceptions lists the few parameters that need to be treated
+ * differently, and kIgnoredParams the ones the convention catches by mistake.
+ *
+ * Discovery has to be by name at runtime rather than through px4::params::,
+ * because some of the parameters are defined by optional modules (bench_test is
+ * built into a handful of board configs only) and commander is built for all of
+ * them. A parameter that is absent from a build is skipped.
+ *
+ * The occupied channels are cached and only re-read on a parameter update, so the
+ * periodic run of the check does no parameter lookups.
+ */
+class RcChannelConflictChecks : public HealthAndArmingCheckBase
+{
+public:
+	RcChannelConflictChecks();
+	~RcChannelConflictChecks() = default;
+
+	void checkAndReport(const Context &context, Report &reporter) override;
+
+	void updateParams() override;
+
+private:
+	/**
+	 * How a switch parameter is read.
+	 *
+	 * Channel parameters hold a 1-based raw channel number with 0 meaning
+	 * "unassigned", matching both rc_channels.channels[] (index = value - 1) and
+	 * input_rc.values[] (index = value - 1). Bitmask parameters hold one bit per
+	 * channel with bit 0 = channel 1, and can therefore occupy several channels.
+	 */
+	enum class ParamKind {
+		Channel,
+		Bitmask,
+	};
+
+	/// A channel assignment parameter that is not read the way the naming convention implies.
+	struct ParamException {
+		const char *name;
+		const char *gate_name;      ///< parameter deciding whether the assignment is read at all, nullptr if always read
+		bool gate_active_when_zero; ///< read the assignment while the gate is zero, instead of while it is non-zero
+		ParamKind kind;
+	};
+
+	/// Runtime state for one discovered parameter.
+	struct ChannelAssignment {
+		const char *name{nullptr};
+		param_t handle{PARAM_INVALID};
+		param_t gate_handle{PARAM_INVALID};
+		bool gated{false};
+		bool gate_active_when_zero{false};
+		ParamKind kind{ParamKind::Channel};
+		uint32_t channels{0};       ///< cached result of activeChannels()
+	};
+
+	/// Prefix marking a parameter as an RC channel assignment.
+	static constexpr const char *kChannelParamPrefix = "RC_MAP";
+
+	/**
+	 * The parameters that need more than the naming convention. These are also
+	 * checked even when their name does not match kChannelParamPrefix.
+	 *
+	 * RC_MAP_FLTM_BTN holds a bitmask of up to 6 channels rather than a single
+	 * channel number, and is only read while RC_MAP_FLTMODE is unassigned
+	 * (rc_update.cpp:577), so a mapping behind an active RC_MAP_FLTMODE cannot
+	 * collide with anything.
+	 */
+	static constexpr ParamException kExceptions[] = {
+		{"RC_MAP_FLTM_BTN", "RC_MAP_FLTMODE", true, ParamKind::Bitmask},
+	};
+
+	/**
+	 * Parameters the naming convention picks up that are not exclusive channel
+	 * assignments:
+	 * - RC_MAP_MODE_SW is deprecated and no longer read by rc_update, so a value left
+	 *   over from an old airframe must not block arming
+	 * - RC_MAP_FAILSAFE is documented to sit on the throttle channel (params.c:1207),
+	 *   so overlapping with RC_MAP_THROTTLE is the normal configuration
+	 */
+	static constexpr const char *kIgnoredParams[] = {
+		"RC_MAP_MODE_SW",
+		"RC_MAP_FAILSAFE",
+	};
+
+	static constexpr int kMaxAssignments = 40;
+
+	/// Maximum number of conflicting pairs named in a single burst of messages.
+	static constexpr int kMaxReportedPairs = 3;
+
+	/// How often the message is repeated while the same conflict stands.
+	static constexpr hrt_abstime kConflictMessageInterval = 30_s;
+
+	ChannelAssignment _assignments[kMaxAssignments];
+	int _num_assignments{0};
+
+	/// Channels reported as conflicting last time, to detect a change.
+	uint32_t _reported_conflicts{0};
+	hrt_abstime _last_conflict_message{0};
+
+	orb_advert_t _mavlink_log_pub{nullptr};
+
+	/// Scan the parameter table for channel assignment parameters. Run once, at construction.
+	void discoverAssignments();
+
+	/// @return whether the parameter name follows the channel mapping convention
+	static bool isChannelParamName(const char *name);
+
+	/// Add one parameter to _assignments if it exists and is not already known.
+	void addAssignment(const char *name);
+
+	/// Re-read all assigned channels into the cache.
+	void updateChannelCache();
+
+	/**
+	 * @return a bitmask of the raw RC channels this function currently occupies
+	 *         (bit 0 = channel 1), or 0 when the feature is disabled, no channel is
+	 *         assigned, or the assigned channel is out of range.
+	 */
+	uint32_t activeChannels(const ChannelAssignment &assignment) const;
+
+	/// @return a bitmask of the raw RC channels claimed by more than one function
+	uint32_t conflictingChannels() const;
+
+	/**
+	 * Send a plain text message to the ground station while channels conflict, so
+	 * that a bad assignment is visible immediately rather than only in the arming
+	 * check report. Emitted when the set of conflicting channels changes and then
+	 * repeated every kConflictMessageInterval while it stands.
+	 */
+	void announceConflicts();
+
+	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
+					(ParamInt<px4::params::COM_ARM_RC_CONF>) _param_com_arm_rc_conf
+				       )
+};

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -237,6 +237,21 @@ PARAM_DEFINE_FLOAT(COM_DISARM_PRFLT, 10.0f);
 PARAM_DEFINE_INT32(COM_ARM_WO_GPS, 1);
 
 /**
+ * RC channel conflict check
+ *
+ * Measures taken when two RC channel mapping parameters (RC_MAP_*) name the same
+ * raw RC channel, so that one stick or switch would drive both functions at once.
+ *
+ * A message is shown as soon as the conflicting assignment is made, regardless of
+ * this setting.
+ *
+ * @group Commander
+ * @value 0 Deny arming
+ * @value 1 Warning only
+ */
+PARAM_DEFINE_INT32(COM_ARM_RC_CONF, 0);
+
+/**
  * Arm switch is a momentary button
  *
  * 0: Arming/disarming triggers on switch transition.

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -322,6 +322,7 @@ MavlinkReceiver::handle_message(mavlink_message_t *msg)
 	case MAVLINK_MSG_ID_GIMBAL_DEVICE_ATTITUDE_STATUS:
 		handle_message_gimbal_device_attitude_status(msg);
 		break;
+
 	case MAVLINK_MSG_ID_DTRG_OFFBOARD: //DTRG Custom
 		handle_message_dtrg_offboard(msg);
 		break;
@@ -462,7 +463,8 @@ MavlinkReceiver::evaluate_target_ok(int command, int target_system, int target_c
 
 
 // DTRG CUSTOM
-void MavlinkReceiver::handle_message_dtrg_offboard(mavlink_message_t *msg){
+void MavlinkReceiver::handle_message_dtrg_offboard(mavlink_message_t *msg)
+{
 	// decode the mavlink message using the MACRO written decode method
 	mavlink_dtrg_offboard_t m;
 	mavlink_msg_dtrg_offboard_decode(msg, &m);

--- a/src/modules/mavlink/streams/DTRG_OFFBOARD.hpp
+++ b/src/modules/mavlink/streams/DTRG_OFFBOARD.hpp
@@ -47,56 +47,56 @@
 class MavlinkStreamDTRGOffboard : public MavlinkStream
 {
 public:
-    static MavlinkStream *new_instance(Mavlink *mavlink)
-    {
-        return new MavlinkStreamBMavlinkStreamDTRGOffboard(mavlink);
-    }
-    const char *get_name() const
-    {
-        return MavlinkMavlinkStreamDTRGOffboard::get_name_static();
-    }
-    static const char *get_name_static()
-    {
-        return "DTRG_OFFBOARD";
-    }
-    static uint16_t get_id_static()
-    {
-        return MAVLINK_MSG_ID_DTRG_OFFBOARD;
-    }
-    uint16_t get_id()
-    {
-        return get_id_static();
-    }
-    unsigned get_size()
-    {
-        return MAVLINK_MSG_ID_DTRG_OFFBOARD_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
-    }
+	static MavlinkStream *new_instance(Mavlink *mavlink)
+	{
+		return new MavlinkStreamBMavlinkStreamDTRGOffboard(mavlink);
+	}
+	const char *get_name() const
+	{
+		return MavlinkMavlinkStreamDTRGOffboard::get_name_static();
+	}
+	static const char *get_name_static()
+	{
+		return "DTRG_OFFBOARD";
+	}
+	static uint16_t get_id_static()
+	{
+		return MAVLINK_MSG_ID_DTRG_OFFBOARD;
+	}
+	uint16_t get_id()
+	{
+		return get_id_static();
+	}
+	unsigned get_size()
+	{
+		return MAVLINK_MSG_ID_DTRG_OFFBOARD_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
+	}
 
 private:
-    uORB::Subscription _dtrg_offboard_sub{ORB_ID::dtrg_custom};
+	uORB::Subscription _dtrg_offboard_sub{ORB_ID::dtrg_custom};
 
-    /* do not allow top copying this class */
-    MavlinkStreamDTRGOffboard(MavlinkStreamDTRGOffboard &);
-    MavlinkStreamDTRGOffboard& operator = (const MavlinkStreamDTRGOffboard &);
+	/* do not allow top copying this class */
+	MavlinkStreamDTRGOffboard(MavlinkStreamDTRGOffboard &);
+	MavlinkStreamDTRGOffboard &operator = (const MavlinkStreamDTRGOffboard &);
 
 protected:
-    explicit MavlinkStreamDTRGOffboard(Mavlink *mavlink) : MavlinkStream(mavlink)
-    {}
+	explicit MavlinkStreamDTRGOffboard(Mavlink *mavlink) : MavlinkStream(mavlink)
+	{}
 
 	bool send() override
 	{
 		bool updated = false;
-			offboard_sp_s offboard_sp;
+		offboard_sp_s offboard_sp;
 
-			if (_dtrg_offboard_sub.update(&offboard_sp)) {
-                		// mavlink_battery_status_demo_t is the MAVLink message object
-				mavlink_dtrg_offboard_t offboard_msg{};
+		if (_dtrg_offboard_sub.update(&offboard_sp)) {
+			// mavlink_battery_status_demo_t is the MAVLink message object
+			mavlink_dtrg_offboard_t offboard_msg{};
 
-				offboard_msg.offboard_sp = offboard_sp.offboard_sp;
+			offboard_msg.offboard_sp = offboard_sp.offboard_sp;
 
-				mavlink_msg_dtrg_offboard_send_struct(_mavlink->get_channel(), &offboard_msg);
-				updated = true;
-			}
+			mavlink_msg_dtrg_offboard_send_struct(_mavlink->get_channel(), &offboard_msg);
+			updated = true;
+		}
 
 		return updated;
 	}

--- a/src/modules/mavlink/streams/SYS_STATUS.hpp
+++ b/src/modules/mavlink/streams/SYS_STATUS.hpp
@@ -180,29 +180,29 @@ private:
 
 			// Fill in the errors_count fields
 			msg.errors_count1 =
-			((sequential_desaturation.x_sat > 0.01f)) |
-			((sequential_desaturation.y_sat > 0.01f) << 1) |
-			((sequential_desaturation.z_sat > 0.01f) << 2) |
-			((sequential_desaturation.roll_sat > 0.01f) << 3) |
-			((sequential_desaturation.pitch_sat > 0.01f) << 4) |
-			((sequential_desaturation.yaw_sat > 0.01f) << 5);
+				((sequential_desaturation.x_sat > 0.01f)) |
+				((sequential_desaturation.y_sat > 0.01f) << 1) |
+				((sequential_desaturation.z_sat > 0.01f) << 2) |
+				((sequential_desaturation.roll_sat > 0.01f) << 3) |
+				((sequential_desaturation.pitch_sat > 0.01f) << 4) |
+				((sequential_desaturation.yaw_sat > 0.01f) << 5);
 
 			// check if any motor is near / at saturation
 			const float upper_bound = 0.9f;
 
 			msg.errors_count2 =
-			((actuator_motors.control[0] > upper_bound)) |
-			((actuator_motors.control[1] > upper_bound) << 1) |
-			((actuator_motors.control[2] > upper_bound) << 2) |
-			((actuator_motors.control[3] > upper_bound) << 3) |
-			((actuator_motors.control[4] > upper_bound) << 4) |
-			((actuator_motors.control[5] > upper_bound) << 5) |
-			((actuator_motors.control[6] > upper_bound) << 6) |
-			((actuator_motors.control[7] > upper_bound) << 7);
+				((actuator_motors.control[0] > upper_bound)) |
+				((actuator_motors.control[1] > upper_bound) << 1) |
+				((actuator_motors.control[2] > upper_bound) << 2) |
+				((actuator_motors.control[3] > upper_bound) << 3) |
+				((actuator_motors.control[4] > upper_bound) << 4) |
+				((actuator_motors.control[5] > upper_bound) << 5) |
+				((actuator_motors.control[6] > upper_bound) << 6) |
+				((actuator_motors.control[7] > upper_bound) << 7);
 
 			msg.errors_count3 =
-			(horizontal_thrust_limit.x_sat) |
-			((horizontal_thrust_limit.y_sat) << 2);
+				(horizontal_thrust_limit.x_sat) |
+				((horizontal_thrust_limit.y_sat) << 2);
 
 			msg.errors_count4 = 706; // tell the status monitor that this code is running
 

--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -115,7 +115,7 @@ private:
 
 	//for DTRG horitontal thrust
 	uORB::Subscription _rc_channels_sub{ORB_ID(rc_channels)};
-	struct rc_channels_s _rc_channels{};
+	struct rc_channels_s _rc_channels {};
 	uORB::Publication<horizontal_thrust_limit_s>	     _horizontal_thrust_limit_pub{ORB_ID(horizontal_thrust_limit)};
 
 	uORB::SubscriptionCallbackWorkItem _vehicle_attitude_sub{this, ORB_ID(vehicle_attitude)};
@@ -137,7 +137,6 @@ private:
 	bool _heading_good_for_control{true}; // initialized true to have heading lock when local position never published
 	float _unaided_heading{NAN}; // initialized NAN to not distract heading lock when local position never published
 	float _man_tilt_max{0.f};			/**< maximum tilt allowed for manual flight [rad] */
-	float _ht_gain{0.f};                   	/**< DTRG horizontal thrust rate */
 	int _ht_en{0};                       	/**< DTRG horizontal thrust enable */
 	int _ht_rc_en_add{-1};				/**< DTRF HT RC enable channel */
 	// 0-based RC channel indices, -1 when the channel parameter is 0 (input disabled)
@@ -211,7 +210,8 @@ private:
 		(ParamFloat<px4::params::DTRG_HT_MAX>)      _param_dtrg_ht_max,		/**< horizontal thrust Limit */
 		(ParamFloat<px4::params::DTRG_HT_R_MAX>)    _param_dtrg_ht_r_max,	/**< horizontal thrust roll angle Limit */
 		(ParamFloat<px4::params::DTRG_HT_P_MAX>)    _param_dtrg_ht_p_max,	/**< horizontal thrust pitch angle Limit */
-		(ParamInt<px4::params::DTRG_HT_MASK>)       _param_dtrg_ht_mask		/**< HT gmask for pitching and rolling using HT thrust*/
+		(ParamInt<px4::params::DTRG_HT_MASK>)
+		_param_dtrg_ht_mask		/**< HT gmask for pitching and rolling using HT thrust*/
 
 	)
 };

--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -150,7 +150,7 @@ private:
 	/**
 	 * Tilt setpoint from a DTRG-assigned RC channel.
 	 *
-	 * @param channel_index 0-based RC channel, or -1 when DTRG_HT_R/DTRG_HT_P is 0
+	 * @param channel_index 0-based RC channel, or -1 when RC_MAP_HT_ROLL/RC_MAP_HT_PITCH is 0
 	 * @param limit         magnitude limit [rad], from DTRG_HT_R_MAX / DTRG_HT_P_MAX
 	 * @return              0 when the input is disabled, out of range or inside the deadzone
 	 */
@@ -204,9 +204,9 @@ private:
 		(ParamFloat<px4::params::COM_SPOOLUP_TIME>) _param_com_spoolup_time,
 
 		(ParamInt<px4::params::DTRG_HT_EN>)         _param_dtrg_ht_en,		/**< horizontal thrust feature */
-		(ParamInt<px4::params::DTRG_HT_RC_EN>)      _param_dtrg_ht_rc_en,	/**< horizontal thrust enable RC channel*/
-		(ParamInt<px4::params::DTRG_HT_R>)  	    _param_dtrg_h_t_R,		/**< horizontal thrust Roll channel */
-		(ParamInt<px4::params::DTRG_HT_P>)  	    _param_dtrg_h_t_P,		/**< horizontal thrust Pitch channel */
+		(ParamInt<px4::params::RC_MAP_HT_MODE>)      _param_dtrg_ht_rc,	/**< horizontal thrust enable RC channel*/
+		(ParamInt<px4::params::RC_MAP_HT_ROLL>)  	    _param_dtrg_h_t_R,		/**< horizontal thrust Roll channel */
+		(ParamInt<px4::params::RC_MAP_HT_PITCH>)  	    _param_dtrg_h_t_P,		/**< horizontal thrust Pitch channel */
 		(ParamFloat<px4::params::DTRG_HT_MAX>)      _param_dtrg_ht_max,		/**< horizontal thrust Limit */
 		(ParamFloat<px4::params::DTRG_HT_R_MAX>)    _param_dtrg_ht_r_max,	/**< horizontal thrust roll angle Limit */
 		(ParamFloat<px4::params::DTRG_HT_P_MAX>)    _param_dtrg_ht_p_max,	/**< horizontal thrust pitch angle Limit */

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -108,9 +108,9 @@ MulticopterAttitudeControl::parameters_updated()
 	_ht_en = _param_dtrg_ht_en.get();
 
 	if (_ht_en) {
-		_ht_rc_en_add = _param_dtrg_ht_rc_en.get() - 1;
+		_ht_rc_en_add = _param_dtrg_ht_rc.get() - 1;
 		_ht_limit = _param_dtrg_ht_max.get();
-		// DTRG_HT_R / DTRG_HT_P of 0 means the input is disabled. Keep the sentinel
+		// RC_MAP_HT_ROLL / RC_MAP_HT_PITCH of 0 means the input is disabled. Keep the sentinel
 		// at -1 rather than letting the -1 offset produce a negative index into
 		// rc_channels.channels[].
 		_ht_r_add = (_param_dtrg_h_t_R.get() > 0) ? (_param_dtrg_h_t_R.get() - 1) : -1;

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -106,8 +106,9 @@ MulticopterAttitudeControl::parameters_updated()
 
 	//DTRG horizontal thrust Params
 	_ht_en = _param_dtrg_ht_en.get();
-	if (_ht_en){
-		_ht_rc_en_add = _param_dtrg_ht_rc_en.get()-1;
+
+	if (_ht_en) {
+		_ht_rc_en_add = _param_dtrg_ht_rc_en.get() - 1;
 		_ht_limit = _param_dtrg_ht_max.get();
 		// DTRG_HT_R / DTRG_HT_P of 0 means the input is disabled. Keep the sentinel
 		// at -1 rather than letting the -1 offset produce a negative index into
@@ -199,7 +200,10 @@ MulticopterAttitudeControl::generate_attitude_setpoint(const Quatf &q, float dt)
 	_stick_yaw.generateYawSetpoint(attitude_setpoint.yaw_sp_move_rate, _yaw_setpoint_stabilized, yaw_stick_input, yaw, dt,
 				       _unaided_heading);
 
-	if (_ht_en) _rc_channels_sub.update(&_rc_channels);
+	if (_ht_en) {
+		_rc_channels_sub.update(&_rc_channels);
+	}
+
 	/*
 	 * Input mapping for roll & pitch setpoints
 	 * ----------------------------------------
@@ -219,15 +223,16 @@ MulticopterAttitudeControl::generate_attitude_setpoint(const Quatf &q, float dt)
 
 
 
-	if (htSwitchActive()){
+	if (htSwitchActive()) {
 		// Roll/pitch come from the assigned aux channels, scaled by the DTRG angle
 		// limits (DTRG_HT_R_MAX / DTRG_HT_P_MAX) rather than the manual tilt max.
 		// A channel parameter of 0 disables that axis, leaving its tilt at 0.
 		v = Vector2f(_man_roll_input_filter.update(dtrgAuxTiltSetpoint(_ht_r_add, _ht_r_limit)),
 			     -_man_pitch_input_filter.update(dtrgAuxTiltSetpoint(_ht_p_add, _ht_p_limit)));
-	}else{
+
+	} else {
 		v = Vector2f(_man_roll_input_filter.update(_manual_control_setpoint.roll * _man_tilt_max),
-				      -_man_pitch_input_filter.update(_manual_control_setpoint.pitch * _man_tilt_max));
+			     -_man_pitch_input_filter.update(_manual_control_setpoint.pitch * _man_tilt_max));
 	}
 
 	float v_norm = v.norm(); // the norm of v defines the tilt angle

--- a/src/modules/mc_att_control/mc_att_control_params.c
+++ b/src/modules/mc_att_control/mc_att_control_params.c
@@ -59,23 +59,32 @@ PARAM_DEFINE_INT32(DTRG_HT_EN, 0);
  *
  *
  *
- * Enable the horizontal thrust control via RC channel, Defualts to 8 which is default arming channel.
- * If you would like to have the UAV fly only in HT mode then this can be set to 5 or the arming channel.
+ * Raw RC channel (input_rc) that enables horizontal thrust control while it reads high.
+ * Disabled by default; if you would like to have the UAV fly only in HT mode then this
+ * can be set to the arming channel.
  *
- * WARNING - ensure that the selected channel is not used for any other function and that the channel is correctly configured in the radio
- * @value 5 (channel 5)
- * @value 6 (channel 6)
- * @value 7 (channel 7)
- * @value 8 Aux 1 (channel 8)
- * @value 9 Aux 2 (channel 9)
- * @value 10 Aux 3 (channel 10)
- * @value 11 Aux 4 (channel 11)
- * @value 12 Aux 5 (channel 12)
- * @value 13 Aux 6 (channel 13)
+ * The channel must not be used for any other function - arming is blocked while it is
+ * also assigned to another RC_MAP parameter - and it must be correctly configured in the radio.
+ *
+ * @min 0
+ * @max 16
+ * @value 0 Disabled
+ * @value 5 Channel 5
+ * @value 6 Channel 6
+ * @value 7 Channel 7
+ * @value 8 Channel 8
+ * @value 9 Channel 9
+ * @value 10 Channel 10
+ * @value 11 Channel 11
+ * @value 12 Channel 12
+ * @value 13 Channel 13
+ * @value 14 Channel 14
+ * @value 15 Channel 15
+ * @value 16 Channel 16
  * @reboot_required true
  * @group DTRG
  */
-PARAM_DEFINE_INT32(DTRG_HT_RC_EN, 8);
+PARAM_DEFINE_INT32(RC_MAP_HT_MODE, 0);
 
 /**
  * Horizontal Thrust XY Limit

--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -309,8 +309,8 @@ void MulticopterPositionControl::parameters_update(bool force)
 		_ht_en = _param_dtrg_ht_en.get();
 
 		if (_ht_en) {
-			_ht_rc_en_add = _param_dtrg_ht_rc_en.get() - 1;
-			// DTRG_HT_R / DTRG_HT_P of 0 means the input is disabled. Keep the
+			_ht_rc_en_add = _param_dtrg_ht_rc.get() - 1;
+			// RC_MAP_HT_ROLL / RC_MAP_HT_PITCH of 0 means the input is disabled. Keep the
 			// sentinel at -1 rather than letting the -1 offset produce a negative
 			// index into rc_channels.channels[].
 			_ht_r_add = (_param_dtrg_ht_R.get() > 0) ? (_param_dtrg_ht_R.get() - 1) : -1;
@@ -662,7 +662,7 @@ void MulticopterPositionControl::Run()
 				if (!_vehicle_control_mode.flag_control_offboard_enabled) {
 					// if offboard is not enabled, use the RC channels to get roll and pitch setpoints
 					// setpoints are constrained to the limits set by the with 0.02f deadzone.
-					// DTRG_HT_R / DTRG_HT_P of 0 disables that axis' stick input, which
+					// RC_MAP_HT_ROLL / RC_MAP_HT_PITCH of 0 disables that axis' stick input, which
 					// leaves the corresponding setpoint at 0 (level).
 					roll_setpoint = dtrgAuxTiltSetpoint(_ht_r_add, _ht_r_limit);
 					pitch_setpoint = dtrgAuxTiltSetpoint(_ht_p_add, _ht_p_limit);

--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -307,8 +307,9 @@ void MulticopterPositionControl::parameters_update(bool force)
 
 		//DTRG
 		_ht_en = _param_dtrg_ht_en.get();
-		if (_ht_en){
-			_ht_rc_en_add = _param_dtrg_ht_rc_en.get()-1;
+
+		if (_ht_en) {
+			_ht_rc_en_add = _param_dtrg_ht_rc_en.get() - 1;
 			// DTRG_HT_R / DTRG_HT_P of 0 means the input is disabled. Keep the
 			// sentinel at -1 rather than letting the -1 offset produce a negative
 			// index into rc_channels.channels[].
@@ -633,6 +634,7 @@ void MulticopterPositionControl::Run()
 					_control.update(dt);
 				}
 			}
+
 			// Publish internal position control setpoints
 			// on top of the input/feed-forward setpoints these containt the PID corrections
 			// This message is used by other modules (such as Landdetector) to determine vehicle intention.
@@ -652,20 +654,21 @@ void MulticopterPositionControl::Run()
 			vehicle_attitude_setpoint_s attitude_setpoint{};
 			const bool ht_rc_enabled = (_ht_rc_en_add >= 0)
 						   && (_ht_rc_en_add < static_cast<int>(sizeof(_rc_channels.channels) / sizeof(
-									   _rc_channels.channels[0])))
+								   _rc_channels.channels[0])))
 						   && (_rc_channels.channels[_ht_rc_en_add] > 0.5f);
 
-			if(_ht_en && ht_rc_enabled){
+			if (_ht_en && ht_rc_enabled) {
 
-				if(!_vehicle_control_mode.flag_control_offboard_enabled){
+				if (!_vehicle_control_mode.flag_control_offboard_enabled) {
 					// if offboard is not enabled, use the RC channels to get roll and pitch setpoints
 					// setpoints are constrained to the limits set by the with 0.02f deadzone.
 					// DTRG_HT_R / DTRG_HT_P of 0 disables that axis' stick input, which
 					// leaves the corresponding setpoint at 0 (level).
 					roll_setpoint = dtrgAuxTiltSetpoint(_ht_r_add, _ht_r_limit);
 					pitch_setpoint = dtrgAuxTiltSetpoint(_ht_p_add, _ht_p_limit);
-				}else{
-					if (_debug_array_sub.update(&_debug_array)){
+
+				} else {
+					if (_debug_array_sub.update(&_debug_array)) {
 
 						// if offboard is enabled, use the roll and pitch setpoints from the debug array
 						roll_setpoint = _debug_array.data[0]; //first index is roll setpoint
@@ -690,12 +693,15 @@ void MulticopterPositionControl::Run()
 				if (_dtrg_ht_mask == 1) {// Roll for y axis
 					final_roll = roll_RP;
 					final_pitch = pitch_setpoint;
+
 				} else if (_dtrg_ht_mask == 2) { //Pitch for x axis
 					final_pitch = pitch_RP;
 					final_roll = roll_setpoint;
+
 				} else if (_dtrg_ht_mask == 3) { //ROLL AND PITCH AND HT THRUST (WARNING Might be unstable)
 					final_roll = roll_RP;
 					final_pitch = pitch_RP;
+
 				} else {
 					final_roll = roll_setpoint;
 					final_pitch = pitch_setpoint;
@@ -707,15 +713,19 @@ void MulticopterPositionControl::Run()
 				q_sp.copyTo(attitude_setpoint.q_d);
 				// convert thrusts from inertial to body frame
 				Vector3f thrust_frd = q_sp.rotateVectorInverse(Vector3f(local_pos_sp.thrust[0],
-					local_pos_sp.thrust[1], local_pos_sp.thrust[2]));
+						      local_pos_sp.thrust[1], local_pos_sp.thrust[2]));
+
 				// Pick and Choose the horizontal thrust stuff using parameter
 				if (_dtrg_ht_mask == 1) { //roll for y
 					attitude_setpoint.thrust_body[0] =  thrust_frd(0); //thrust for x
+
 				} else if (_dtrg_ht_mask == 2) { //pitch for x
 					attitude_setpoint.thrust_body[1] =  thrust_frd(1); //thrust for y
+
 				} else if (_dtrg_ht_mask == 3) { //ROLL AND PITCH AND HT THRUST (WARNING Might be unstable)
 					attitude_setpoint.thrust_body[0] =  thrust_frd(0);
 					attitude_setpoint.thrust_body[1] =  thrust_frd(1);
+
 				} else {
 					attitude_setpoint.thrust_body[0] =  thrust_frd(0);
 					attitude_setpoint.thrust_body[1] =  thrust_frd(1);
@@ -732,10 +742,12 @@ void MulticopterPositionControl::Run()
 
 				//vertical thrust
 				attitude_setpoint.thrust_body[2] = thrust_frd(2);
-			}else{
+
+			} else {
 				//Standard attitude setpoint
 				_control.getAttitudeSetpoint(attitude_setpoint);
 			}
+
 			attitude_setpoint.timestamp = hrt_absolute_time();
 			_vehicle_attitude_setpoint_pub.publish(attitude_setpoint);
 

--- a/src/modules/mc_pos_control/MulticopterPositionControl.hpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.hpp
@@ -149,8 +149,6 @@ private:
 	int _ht_en{0}; 				/**< DTRG horizontal thrust Enabled*/
 	int _ht_rc_en_add{-1};			/**< DTRF HT RC enable channel */
 	int _dtrg_ht_mask = 0;
-	int _ht_x_add{-1};                     	/**< DTRG horizontal thrust X channel */
-	int _ht_y_add{-1};                     	/**< DTRG horizontal thrust Y channel */
 	// 0-based RC channel indices, -1 when the channel parameter is 0 (input disabled)
 	int _ht_r_add{-1};                     	/**< DTRG horizontal thrust Roll channel */
 	int _ht_p_add{-1}; 	       		/**< DTRG horizontal thrust Pitch channel */
@@ -236,7 +234,8 @@ private:
 		//DTRG
 		(ParamInt<px4::params::DTRG_HT_EN>)         _param_dtrg_ht_en, 		/**< enable the dtrg 6d offboard control*/
 		(ParamInt<px4::params::DTRG_HT_RC_EN>)      _param_dtrg_ht_rc_en,	/**< horizontal thrust enable RC channel*/
-		(ParamInt<px4::params::DTRG_HT_MASK>)       _param_dtrg_ht_mask,	/**< HT gmask for pitching and rolling using HT thrust*/
+		(ParamInt<px4::params::DTRG_HT_MASK>)
+		_param_dtrg_ht_mask,	/**< HT gmask for pitching and rolling using HT thrust*/
 		(ParamInt<px4::params::DTRG_HT_R>)  	    _param_dtrg_ht_R,		/**< horizontal thrust Roll channel */
 		(ParamInt<px4::params::DTRG_HT_P>)  	    _param_dtrg_ht_P,		/**< horizontal thrust Pitch channel */
 		(ParamFloat<px4::params::DTRG_HT_MAX>)      _param_dtrg_ht_max,		/**< horizontal thrust Limit */

--- a/src/modules/mc_pos_control/MulticopterPositionControl.hpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.hpp
@@ -156,7 +156,7 @@ private:
 	/**
 	 * Scaled tilt setpoint from a DTRG-assigned RC channel.
 	 *
-	 * @param channel_index 0-based RC channel, or -1 when DTRG_HT_R/DTRG_HT_P is 0
+	 * @param channel_index 0-based RC channel, or -1 when RC_MAP_HT_ROLL/RC_MAP_HT_PITCH is 0
 	 * @param limit         magnitude limit [rad]
 	 * @return              0 when the input is disabled, out of range or inside the deadzone
 	 */
@@ -233,11 +233,11 @@ private:
 
 		//DTRG
 		(ParamInt<px4::params::DTRG_HT_EN>)         _param_dtrg_ht_en, 		/**< enable the dtrg 6d offboard control*/
-		(ParamInt<px4::params::DTRG_HT_RC_EN>)      _param_dtrg_ht_rc_en,	/**< horizontal thrust enable RC channel*/
+		(ParamInt<px4::params::RC_MAP_HT_MODE>)     _param_dtrg_ht_rc,	/**< horizontal thrust enable RC channel*/
 		(ParamInt<px4::params::DTRG_HT_MASK>)
 		_param_dtrg_ht_mask,	/**< HT gmask for pitching and rolling using HT thrust*/
-		(ParamInt<px4::params::DTRG_HT_R>)  	    _param_dtrg_ht_R,		/**< horizontal thrust Roll channel */
-		(ParamInt<px4::params::DTRG_HT_P>)  	    _param_dtrg_ht_P,		/**< horizontal thrust Pitch channel */
+		(ParamInt<px4::params::RC_MAP_HT_ROLL>)  	    _param_dtrg_ht_R,		/**< horizontal thrust Roll channel */
+		(ParamInt<px4::params::RC_MAP_HT_PITCH>)  	    _param_dtrg_ht_P,		/**< horizontal thrust Pitch channel */
 		(ParamFloat<px4::params::DTRG_HT_MAX>)      _param_dtrg_ht_max,		/**< horizontal thrust Limit */
 		(ParamFloat<px4::params::DTRG_HT_R_MAX>)    _param_dtrg_ht_r_max,	/**< horizontal thrust roll angle Limit */
 		(ParamFloat<px4::params::DTRG_HT_P_MAX>)    _param_dtrg_ht_p_max

--- a/src/modules/mc_pos_control/multicopter_horizontal_thrust_params.c
+++ b/src/modules/mc_pos_control/multicopter_horizontal_thrust_params.c
@@ -7,42 +7,50 @@
 /**
  * Horizontal thrust Roll channel
  *
- * AUX channel for horizontal thrust roll control in 6DOF mode.
+ * Raw RC channel (input_rc) for horizontal thrust roll control in 6DOF mode.
  *
  * @min 0
  * @max 16
  * @value 0 Disabled
- * @value 9 AUX9
- * @value 10 AUX10
- * @value 11 AUX11
- * @value 12 AUX12
- * @value 13 AUX13
- * @value 14 AUX14
- * @value 15 AUX15
- * @value 16 AUX16
+ * @value 5 Channel 5
+ * @value 6 Channel 6
+ * @value 7 Channel 7
+ * @value 8 Channel 8
+ * @value 9 Channel 9
+ * @value 10 Channel 10
+ * @value 11 Channel 11
+ * @value 12 Channel 12
+ * @value 13 Channel 13
+ * @value 14 Channel 14
+ * @value 15 Channel 15
+ * @value 16 Channel 16
  * @group DTRG
  */
-PARAM_DEFINE_INT32(DTRG_HT_R, 0);
+PARAM_DEFINE_INT32(RC_MAP_HT_ROLL, 0);
 
 /**
  * Horizontal thrust Pitch channel
  *
- * AUX channel for horizontal thrust pitch control in 6DOF mode.
+ * Raw RC channel (input_rc) for horizontal thrust pitch control in 6DOF mode.
  *
  * @min 0
  * @max 16
  * @value 0 Disabled
- * @value 9 AUX9
- * @value 10 AUX10
- * @value 11 AUX11
- * @value 12 AUX12
- * @value 13 AUX13
- * @value 14 AUX14
- * @value 15 AUX15
- * @value 16 AUX16
+ * @value 5 Channel 5
+ * @value 6 Channel 6
+ * @value 7 Channel 7
+ * @value 8 Channel 8
+ * @value 9 Channel 9
+ * @value 10 Channel 10
+ * @value 11 Channel 11
+ * @value 12 Channel 12
+ * @value 13 Channel 13
+ * @value 14 Channel 14
+ * @value 15 Channel 15
+ * @value 16 Channel 16
  * @group DTRG
  */
-PARAM_DEFINE_INT32(DTRG_HT_P, 0);
+PARAM_DEFINE_INT32(RC_MAP_HT_PITCH, 0);
 
 /**
  * Horizontal thrust control mask

--- a/src/modules/mc_rate_control/MulticopterRateControl.cpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.cpp
@@ -198,8 +198,8 @@ MulticopterRateControl::Run()
 			control_allocator_status_s control_allocator_status;
 
 			//prevent further positive control saturation
-			if(_param_antiwindup_en.get()==1){
-				if(_csv_mixer.get()==0){
+			if (_param_antiwindup_en.get() == 1) {
+				if (_csv_mixer.get() == 0) {
 
 					if (_control_allocator_status_sub.update(&control_allocator_status)) {
 						Vector<bool, 3> saturation_positive;
@@ -217,13 +217,12 @@ MulticopterRateControl::Run()
 						}
 
 
-					// TODO: send the unallocated value directly for better anti-windup
-					_rate_control.setSaturationStatus(saturation_positive, saturation_negative);
+						// TODO: send the unallocated value directly for better anti-windup
+						_rate_control.setSaturationStatus(saturation_positive, saturation_negative);
 					}
 
 
-				}
-				else{
+				} else {
 					_param_antiwindup_en.set(0);
 					_param_antiwindup_en.commit();
 				}

--- a/src/modules/mc_rate_control/MulticopterRateControl.hpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.hpp
@@ -128,7 +128,6 @@ private:
 	matrix::Vector3f _thrust_setpoint{};
 
 	matrix::Vector3f _vector_thrust_sp{};
-	float _vec_thr_xy_p; /**< gain for vector thrust XY direction. */
 
 	float _energy_integration_time{0.0f};
 	float _control_energy[4] {};


### PR DESCRIPTION
Reduces possibility of overloading one channel with two functionality by preventing arming if one channels are used for two different parameters. Have to be named "RC_MAP_". Parameters were renamed to adjust that 
